### PR TITLE
Fix retry after PR auto abort

### DIFF
--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -6,7 +6,7 @@ import hudson.remoting.RequestAbortedException;
 import java.lang.IllegalArgumentException;
 
 
-def executeTestsNode(String osName, String gpuNames, def executeTests, def executeDeploy, Map options)
+def executeTestsNode(String osName, String gpuNames, def executeTests, Map options)
 {
     if(gpuNames && options['executeTests'])
     {
@@ -100,7 +100,7 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, def execu
     }
 }
 
-def executePlatform(String osName, String gpuNames, def executeBuild, def executeTests, def executeDeploy Map options)
+def executePlatform(String osName, String gpuNames, def executeBuild, def executeTests, Map options)
 {
     def retNode =
     {
@@ -123,7 +123,7 @@ def executePlatform(String osName, String gpuNames, def executeBuild, def execut
                     }
                 }
             }
-            executeTestsNode(osName, gpuNames, executeTests, executeDeploy, options)
+            executeTestsNode(osName, gpuNames, executeTests, options)
         }
         catch (e)
         {
@@ -247,7 +247,7 @@ def call(String platforms, def executePreBuild, def executeBuild, def executeTes
                         }
                     }
 
-                    tasks[osName]=executePlatform(osName, gpuNames, executeBuild, executeTests, executeDeploy, options)
+                    tasks[osName]=executePlatform(osName, gpuNames, executeBuild, executeTests, options)
                 }
                 parallel tasks
             }

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -47,9 +47,6 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                         newOptions['stageName'] = testName ? "${asicName}-${osName}-${testName}" : "${asicName}-${osName}"
                                         newOptions['tests'] = testName ? testName : options.tests
                                         try {
-                                            timeout(0.5){
-                                                sleep(60)
-                                            }
                                             executeTests(osName, asicName, newOptions)
                                             i = options.nodeReallocateTries + 1
                                             successCurrentNode = true

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -62,10 +62,12 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                                     // UserInterruption aborting by user
                                                     // ExceededTimeout aborting by timeout
                                                     // CancelledCause for aborting by new commit
-                                                    println "Interruption cause: ${it.getClass()}"
-                                                    //if (it.getClass().toString().contains("CancelledCause")) {
-                                                       // throw e
-                                                    //}
+                                                    println "Interruption cause: ${it.getClass().toString()}"
+                                                    if (it.getClass().toString().contains("CancelledCause")) {
+                                                        println "GOT NEW COMMIT"
+                                                        sleep(10)
+                                                        throw e
+                                                    }
                                                 }
                                             }
                                             // Abort PRs

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -67,6 +67,7 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                                     println "Interruption cause: ${causeClassName}"
                                                     if (causeClassName.contains("CancelledCause")) {
                                                         println "GOT NEW COMMIT"
+                                                        executeDeploy = null
                                                         throw e
                                                     }
                                                 }

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -67,16 +67,10 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                                     println "Interruption cause: ${causeClassName}"
                                                     if (causeClassName.contains("CancelledCause")) {
                                                         println "GOT NEW COMMIT"
-                                                        // sleep(10)
                                                         throw e
                                                     }
                                                 }
                                             }
-                                            // Abort PRs
-                                            //if (options.containsKey("isPR") &&  options.isPR == true) {
-                                            //    println "[INFO] This build was aborted due to new PR was appeared."
-                                            //    i = options.nodeReallocateTries + 1
-                                            //}
 
                                             // change PC after first failed tries and don't change in the last try
                                             if (i < nodesCount - 1 && nodesCount != 1) {

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -6,7 +6,7 @@ import hudson.remoting.RequestAbortedException;
 import java.lang.IllegalArgumentException;
 
 
-def executeTestsNode(String osName, String gpuNames, def executeTests, Map options)
+def executeTestsNode(String osName, String gpuNames, def executeTests, def executeDeploy, Map options)
 {
     if(gpuNames && options['executeTests'])
     {
@@ -100,7 +100,7 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
     }
 }
 
-def executePlatform(String osName, String gpuNames, def executeBuild, def executeTests, Map options)
+def executePlatform(String osName, String gpuNames, def executeBuild, def executeTests, def executeDeploy Map options)
 {
     def retNode =
     {
@@ -123,7 +123,7 @@ def executePlatform(String osName, String gpuNames, def executeBuild, def execut
                     }
                 }
             }
-            executeTestsNode(osName, gpuNames, executeTests, options)
+            executeTestsNode(osName, gpuNames, executeTests, executeDeploy, options)
         }
         catch (e)
         {
@@ -247,7 +247,7 @@ def call(String platforms, def executePreBuild, def executeBuild, def executeTes
                         }
                     }
 
-                    tasks[osName]=executePlatform(osName, gpuNames, executeBuild, executeTests, options)
+                    tasks[osName]=executePlatform(osName, gpuNames, executeBuild, executeTests, executeDeploy, options)
                 }
                 parallel tasks
             }

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -57,15 +57,17 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                             println "Exception cause: ${e.getCause()}"
                                             println "Exception stack trace: ${e.getStackTrace()}"
 
-                                            if (e.getClass().toString().contains("FlowInterruptedException") || e.getClass().toString().contains("AbortException")) {
+                                            String exceptionClassName = e.getClass().toString()
+                                            if (exceptionClassName.contains("FlowInterruptedException") || exceptionClassName.contains("AbortException")) {
                                                 e.getCauses().each(){
                                                     // UserInterruption aborting by user
                                                     // ExceededTimeout aborting by timeout
                                                     // CancelledCause for aborting by new commit
-                                                    println "Interruption cause: ${it.getClass().toString()}"
-                                                    if (it.getClass().toString().contains("CancelledCause")) {
+                                                    String causeClassName = it.getClass().toString()
+                                                    println "Interruption cause: ${causeClassName}"
+                                                    if (causeClassName.contains("CancelledCause")) {
                                                         println "GOT NEW COMMIT"
-                                                        sleep(10)
+                                                        // sleep(10)
                                                         throw e
                                                     }
                                                 }

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -57,7 +57,7 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                             println "Exception cause: ${e.getCause()}"
                                             println "Exception stack trace: ${e.getStackTrace()}"
 
-                                            if (e.getClass.toString().contains("FlowInterruptedException")) {
+                                            if (e.getClass().toString().contains("FlowInterruptedException")) {
                                                 e.getCauses().each(){
                                                     // UserInterruption
                                                     // ExceededTimeout

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -57,7 +57,7 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                             println "Exception cause: ${e.getCause()}"
                                             println "Exception stack trace: ${e.getStackTrace()}"
                                             e.getCauses().each(){
-                                                println "Interruption cause: ${it.getShortDescription()}"
+                                                println "Interruption cause: ${it.getClass()}"
                                             }
                                         } catch(Exception e) {
                                             println "[ERROR] Failed during tests on ${env.NODE_NAME} node"

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -50,6 +50,15 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                             executeTests(osName, asicName, newOptions)
                                             i = options.nodeReallocateTries + 1
                                             successCurrentNode = true
+                                        } catch (FlowInterruptedException e) {
+                                            println "[ERROR] GOT FlowInterruptedException"
+                                            println "Exception: ${e.toString()}"
+                                            println "Exception message: ${e.getMessage()}"
+                                            println "Exception cause: ${e.getCause()}"
+                                            println "Exception stack trace: ${e.getStackTrace()}"
+                                            e.getCauses().each(){
+                                                println "Interruption cause: ${it}"
+                                            }
                                         } catch(Exception e) {
                                             println "[ERROR] Failed during tests on ${env.NODE_NAME} node"
                                             println "Exception: ${e.toString()}"

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -47,7 +47,7 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                         newOptions['stageName'] = testName ? "${asicName}-${osName}-${testName}" : "${asicName}-${osName}"
                                         newOptions['tests'] = testName ? testName : options.tests
                                         try {
-                                            timeout(30){
+                                            timeout(0.5){
                                                 sleep(60)
                                             }
                                             executeTests(osName, asicName, newOptions)

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -57,7 +57,7 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                             println "Exception cause: ${e.getCause()}"
                                             println "Exception stack trace: ${e.getStackTrace()}"
                                             e.getCauses().each(){
-                                                println "Interruption cause: ${it}"
+                                                println "Interruption cause: ${it.getShortDescription()}"
                                             }
                                         } catch(Exception e) {
                                             println "[ERROR] Failed during tests on ${env.NODE_NAME} node"

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -57,7 +57,7 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                             println "Exception cause: ${e.getCause()}"
                                             println "Exception stack trace: ${e.getStackTrace()}"
 
-                                            if (e.getClass().toString().contains("FlowInterruptedException")) {
+                                            if (e.getClass().toString().contains("FlowInterruptedException") || e.getClass().toString().contains("AbortException")) {
                                                 e.getCauses().each(){
                                                     // UserInterruption aborting by user
                                                     // ExceededTimeout aborting by timeout

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -67,7 +67,6 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                                     println "Interruption cause: ${causeClassName}"
                                                     if (causeClassName.contains("CancelledCause")) {
                                                         println "GOT NEW COMMIT"
-                                                        executeDeploy = null
                                                         throw e
                                                     }
                                                 }
@@ -256,6 +255,18 @@ def call(String platforms, def executePreBuild, def executeBuild, def executeTes
                 println(e.toString());
                 println(e.getMessage());
                 currentBuild.result = "FAILURE"
+                String exceptionClassName = e.getClass().toString()
+                if (exceptionClassName.contains("FlowInterruptedException") || exceptionClassName.contains("AbortException")) {
+                    e.getCauses().each(){
+                        // UserInterruption aborting by user
+                        // ExceededTimeout aborting by timeout
+                        // CancelledCause for aborting by new commit
+                        String causeClassName = it.getClass().toString()
+                        if (causeClassName.contains("CancelledCause")) {
+                            executeDeploy = null
+                        }
+                    }
+                }
             }
             finally
             {

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -50,15 +50,6 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                             executeTests(osName, asicName, newOptions)
                                             i = options.nodeReallocateTries + 1
                                             successCurrentNode = true
-                                        } catch (FlowInterruptedException e) {
-                                            println "[ERROR] GOT FlowInterruptedException"
-                                            println "Exception: ${e.toString()}"
-                                            println "Exception message: ${e.getMessage()}"
-                                            println "Exception cause: ${e.getCause()}"
-                                            println "Exception stack trace: ${e.getStackTrace()}"
-                                            e.getCauses().each(){
-                                                println "Interruption cause: ${it.getClass()}"
-                                            }
                                         } catch(Exception e) {
                                             println "[ERROR] Failed during tests on ${env.NODE_NAME} node"
                                             println "Exception: ${e.toString()}"
@@ -66,6 +57,14 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                             println "Exception cause: ${e.getCause()}"
                                             println "Exception stack trace: ${e.getStackTrace()}"
 
+                                            if (e.getClass.toString().contains("FlowInterruptedException")) {
+                                                e.getCauses().each(){
+                                                    // UserInterruption
+                                                    // ExceededTimeout
+                                                    // Cancelled
+                                                    println "Interruption cause: ${it.getClass()}"
+                                                }
+                                            }
                                             // Abort PRs
                                             //if (options.containsKey("isPR") &&  options.isPR == true) {
                                             //    println "[INFO] This build was aborted due to new PR was appeared."

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -100,7 +100,7 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, def execu
     }
 }
 
-def executePlatform(String osName, String gpuNames, def executeBuild, def executeTests, def executeDeploy, Map options)
+def executePlatform(String osName, String gpuNames, def executeBuild, def executeTests, def executeDeploy Map options)
 {
     def retNode =
     {

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -47,6 +47,9 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                         newOptions['stageName'] = testName ? "${asicName}-${osName}-${testName}" : "${asicName}-${osName}"
                                         newOptions['tests'] = testName ? testName : options.tests
                                         try {
+                                            timeout(30, unit:'SECONDS'){
+                                                sleep(60, unit: 'SECONDS')
+                                            }
                                             executeTests(osName, asicName, newOptions)
                                             i = options.nodeReallocateTries + 1
                                             successCurrentNode = true

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -100,7 +100,7 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, def execu
     }
 }
 
-def executePlatform(String osName, String gpuNames, def executeBuild, def executeTests, def executeDeploy Map options)
+def executePlatform(String osName, String gpuNames, def executeBuild, def executeTests, def executeDeploy, Map options)
 {
     def retNode =
     {

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -59,10 +59,13 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
 
                                             if (e.getClass().toString().contains("FlowInterruptedException")) {
                                                 e.getCauses().each(){
-                                                    // UserInterruption
-                                                    // ExceededTimeout
-                                                    // Cancelled
+                                                    // UserInterruption aborting by user
+                                                    // ExceededTimeout aborting by timeout
+                                                    // CancelledCause for aborting by new commit
                                                     println "Interruption cause: ${it.getClass()}"
+                                                    if (it.getClass().contains("CancelledCause")) {
+                                                        throw e
+                                                    }
                                                 }
                                             }
                                             // Abort PRs

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -63,7 +63,7 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                                     // ExceededTimeout aborting by timeout
                                                     // CancelledCause for aborting by new commit
                                                     println "Interruption cause: ${it.getClass()}"
-                                                    if (it.getClass().contains("CancelledCause")) {
+                                                    if (it.getClass().toString().contains("CancelledCause")) {
                                                         throw e
                                                     }
                                                 }

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -63,9 +63,9 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                                     // ExceededTimeout aborting by timeout
                                                     // CancelledCause for aborting by new commit
                                                     println "Interruption cause: ${it.getClass()}"
-                                                    if (it.getClass().toString().contains("CancelledCause")) {
-                                                        throw e
-                                                    }
+                                                    //if (it.getClass().toString().contains("CancelledCause")) {
+                                                       // throw e
+                                                    //}
                                                 }
                                             }
                                             // Abort PRs

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -47,8 +47,8 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
                                         newOptions['stageName'] = testName ? "${asicName}-${osName}-${testName}" : "${asicName}-${osName}"
                                         newOptions['tests'] = testName ? testName : options.tests
                                         try {
-                                            timeout(30, unit:'SECONDS'){
-                                                sleep(60, unit: 'SECONDS')
+                                            timeout(30){
+                                                sleep(60)
                                             }
                                             executeTests(osName, asicName, newOptions)
                                             i = options.nodeReallocateTries + 1


### PR DESCRIPTION
JIRA TICKET
https://adc.luxoft.com/jira/browse/STVCIS-1086

PURPOSE
Fix retries  restarting after build aborting by a new build

EFFECT OF CHANGE
New build abort old build by new commit

TECHNICAL STEPS

- Add FlowInterruptedException check
- Add CauseOfInterruption check
- Cancel deploy if build was interrupted by new build

COMMENTS FOR REWIERS

On this build in console log you can see how it works
At 14:46:31 build was Superseded 
At 14:46:47 printed interruption cause and then printed that there is new incoming commit
Then exception was thrown and retry did not work
At 14:46:48 deploy was cancelled
https://rpr.cis.luxoft.com/job/Vray2RPRConvertToolAuto-Maya/view/change-requests/job/PR-4/31/console