### PR TITLE
Implement option for parallel execute test groups in few modes

### DIFF
--- a/vars/ProblemMessageManager.groovy
+++ b/vars/ProblemMessageManager.groovy
@@ -62,7 +62,7 @@ public class ProblemMessageManager {
         try {
             // ignore general error messages if specific message has already saved
             if (problemScope == ProblemScope.GENERAL) {
-                if (osName) {
+                if (!osName) {
                     if (failReasons.containsKey(stageName)) {
                         return
                     } else {

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -6,6 +6,132 @@ import hudson.remoting.RequestAbortedException;
 import java.lang.IllegalArgumentException;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
+import jenkins.model.Jenkins;
+import groovy.transform.Synchronized;
+import java.util.Iterator;
+
+
+@NonCPS
+@Synchronized
+def getNextTest(Iterator iterator) {
+    if (iterator.hasNext()) {
+        return iterator.next()
+    } else {
+        return null
+    }
+}
+
+
+def getLabels(String osName, String asicName, Map options) {
+    def testerTag = "Tester"
+    if (options.TESTER_TAG){
+        if (options.TESTER_TAG.indexOf(' ') > -1){
+            testerTag = options.TESTER_TAG
+        }else {
+            testerTag = "${options.TESTER_TAG} && Tester"
+        }
+    } 
+    return "${osName} && ${testerTag} && OpenCL && gpu${asicName}"
+}
+
+
+def executeTestsTask(String testName, String osName, String asicName, def executeTests, Map options) {
+    println("Scheduling ${osName}:${asicName} ${testName}")
+
+    Map newOptions = options.clone()
+    newOptions['testResultsName'] = testName ? "testResult-${asicName}-${osName}-${testName}" : "testResult-${asicName}-${osName}"
+    newOptions['stageName'] = testName ? "${asicName}-${osName}-${testName}" : "${asicName}-${osName}"
+    newOptions['tests'] = testName ?: options.tests
+
+    String testerLabels = getLabels(osName, asicName, options)
+
+    def retringFunction = { nodesList, currentTry ->
+        try {
+            executeTests(osName, asicName, newOptions)
+        } catch(Exception e) {
+            // save expected exception message for add it in report
+            String expectedExceptionMessage = ""
+            if (e instanceof ExpectedExceptionWrapper) {
+                expectedExceptionMessage = e.getMessage()
+                e = e.getCause()
+            }
+
+            println "[ERROR] Failed during tests on ${env.NODE_NAME} node"
+            println "Exception: ${e.toString()}"
+            println "Exception message: ${e.getMessage()}"
+            println "Exception cause: ${e.getCause()}"
+            println "Exception stack trace: ${e.getStackTrace()}"
+
+            String exceptionClassName = e.getClass().toString()
+            if (exceptionClassName.contains("FlowInterruptedException")) {
+                e.getCauses().each(){
+                    // UserInterruption aborting by user
+                    // ExceededTimeout aborting by timeout
+                    // CancelledCause for aborting by new commit
+                    String causeClassName = it.getClass().toString()
+                    println "Interruption cause: ${causeClassName}"
+                    if (causeClassName.contains("CancelledCause")) {
+                        expectedExceptionMessage = "Build was aborted by new commit."
+                    } else if (causeClassName.contains("UserInterruption")) {
+                        expectedExceptionMessage = "Build was aborted by user."
+                    } else if ((causeClassName.contains("TimeoutStepExecution") || causeClassName.contains("ExceededTimeout")) && (!expectedExceptionMessage || expectedExceptionMessage == 'Unknown reason')) {
+                        expectedExceptionMessage = "Timeout exceeded (pipelines layer)."
+                    }
+                }
+            } else if (exceptionClassName.contains("ClosedChannelException") || exceptionClassName.contains("RemotingSystemException") || exceptionClassName.contains("InterruptedException")) {
+                expectedExceptionMessage = "Lost connection with machine."
+            }
+
+            // add info about retry to options
+            boolean added = false;
+            String testsOrTestPackage
+            if (newOptions['splitTestsExecution']) {
+                testsOrTestPackage = newOptions['tests']
+            } else if (newOptions['testsPackage']) {
+                testsOrTestPackage = newOptions['testsPackage'].replace(' ', '_')
+            }
+
+            if (!expectedExceptionMessage) {
+                expectedExceptionMessage = "Unexpected exception."
+            }
+
+            if (options.containsKey('nodeRetry')) {
+                Map tryInfo = [host:env.NODE_NAME, link:"${testsOrTestPackage}.${env.NODE_NAME}.retry_${currentTry}.crash.log", exception: expectedExceptionMessage, time: LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))]
+
+                retryLoops: for (testers in options['nodeRetry']) {
+                    if (testers['Testers'].equals(nodesList)){
+                        for (group in testers['Tries']) {
+                            if (group[testsOrTestPackage]) {
+                                group[testsOrTestPackage].add(tryInfo)
+                                added = true
+                                break retryLoops
+                            }
+                        }
+                        // add list for test group if it doesn't exists
+                        testers['Tries'].add([(testsOrTestPackage): [tryInfo]])
+                        added = true
+                        break retryLoops
+                    }
+                }
+
+                if (!added){
+                    options['nodeRetry'].add([Testers: nodesList, gpuName: asicName, osName: osName, Tries: [[(testsOrTestPackage): [tryInfo]]]])
+                }
+                println options['nodeRetry'].inspect()
+            }
+
+            throw e
+        }
+    }
+
+    try {
+        Integer retries_count = options.retriesForTestStage ?: -1
+        run_with_retries(testerLabels, options.TEST_TIMEOUT, retringFunction, true, "Test", newOptions, [], retries_count, osName)
+    } catch (e) {
+        println "Exception: ${e.toString()}"
+        println "Exception message: ${e.getMessage()}"
+    }
+}
 
 
 def executeTestsNode(String osName, String gpuNames, def executeTests, Map options)
@@ -16,115 +142,35 @@ def executeTestsNode(String osName, String gpuNames, def executeTests, Map optio
         gpuNames.split(',').each()
         {
             String asicName = it
-            testTasks["Test-${it}-${osName}"] = {
+            
+            testTasks["Test-${asicName}-${osName}"] = {
                 stage("Test-${asicName}-${osName}") {
                     // if not split - testsList doesn't exists
                     // TODO: replace testsList check to splitExecution var
                     options.testsList = options.testsList ?: ['']
 
-                    options.testsList.each() { testName ->
-                        println("Scheduling ${osName}:${asicName} ${testName}")
-
-                        Map newOptions = options.clone()
-                        newOptions['testResultsName'] = testName ? "testResult-${asicName}-${osName}-${testName}" : "testResult-${asicName}-${osName}"
-                        newOptions['stageName'] = testName ? "${asicName}-${osName}-${testName}" : "${asicName}-${osName}"
-                        newOptions['tests'] = testName ?: options.tests
-
-                        def testerTag = "Tester"
-                        if (options.TESTER_TAG){
-                            if (options.TESTER_TAG.indexOf(' ') > -1){
-                                testerTag = options.TESTER_TAG
-                            }else {
-                                testerTag = "${options.TESTER_TAG} && Tester"
-                            }
-                        } 
-                        def testerLabels = "${osName} && ${testerTag} && OpenCL && gpu${asicName}"
-
-                        def retringFunction = { nodesList, currentTry ->
-                            try {
-                                executeTests(osName, asicName, newOptions)
-                            } catch(Exception e) {
-                                // save expected exception message for add it in report
-                                String expectedExceptionMessage = ""
-                                if (e instanceof ExpectedExceptionWrapper) {
-                                    expectedExceptionMessage = e.getMessage()
-                                    e = e.getCause()
-                                }
-
-                                println "[ERROR] Failed during tests on ${env.NODE_NAME} node"
-                                println "Exception: ${e.toString()}"
-                                println "Exception message: ${e.getMessage()}"
-                                println "Exception cause: ${e.getCause()}"
-                                println "Exception stack trace: ${e.getStackTrace()}"
-
-                                String exceptionClassName = e.getClass().toString()
-                                if (exceptionClassName.contains("FlowInterruptedException")) {
-                                    e.getCauses().each(){
-                                        // UserInterruption aborting by user
-                                        // ExceededTimeout aborting by timeout
-                                        // CancelledCause for aborting by new commit
-                                        String causeClassName = it.getClass().toString()
-                                        println "Interruption cause: ${causeClassName}"
-                                        if (causeClassName.contains("CancelledCause")) {
-                                            expectedExceptionMessage = "Build was aborted by new commit"
-                                        } else if (causeClassName.contains("UserInterruption")) {
-                                            expectedExceptionMessage = "Build was aborted by user"
-                                        } else if ((causeClassName.contains("TimeoutStepExecution") || causeClassName.contains("ExceededTimeout")) && (!expectedExceptionMessage || expectedExceptionMessage == 'Unknown reason')) {
-                                            expectedExceptionMessage = "Timeout exceeded (pipelines layer)"
-                                        }
-                                    }
-                                } else if (exceptionClassName.contains("ClosedChannelException") || exceptionClassName.contains("RemotingSystemException") || exceptionClassName.contains("InterruptedException")) {
-                                    expectedExceptionMessage = "Lost connection with machine"
-                                }
-
-                                // add info about retry to options
-                                boolean added = false;
-                                String testsOrTestPackage = newOptions['tests'];
-                                if (testsOrTestPackage == ''){
-                                    testsOrTestPackage = newOptions['testsPackage'].replace(' ', '_')
-                                }
-
-                                if (!expectedExceptionMessage) {
-                                    expectedExceptionMessage = "Unexpected exception"
-                                }
-
-                                if (options.containsKey('nodeRetry')) {
-                                    Map tryInfo = [host:env.NODE_NAME, link:"${testsOrTestPackage}.${env.NODE_NAME}.retry_${currentTry}.crash.log", exception: expectedExceptionMessage, time: LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))]
-
-                                    retryLoops: for (testers in options['nodeRetry']) {
-                                        if (testers['Testers'].equals(nodesList)){
-                                            for (group in testers['Tries']) {
-                                                if (group[testsOrTestPackage]) {
-                                                    group[testsOrTestPackage].add(tryInfo)
-                                                    added = true
-                                                    break retryLoops
-                                                }
-                                            }
-                                            // add list for test group if it doesn't exists
-                                            testers['Tries'].add([(testsOrTestPackage): [tryInfo]])
-                                            added = true
-                                            break retryLoops
-                                        }
-                                    }
-
-                                    if (!added){
-                                        options['nodeRetry'].add([Testers: nodesList, gpuName: asicName, osName: osName, Tries: [[(testsOrTestPackage): [tryInfo]]]])
-                                    }
-                                    println options['nodeRetry'].inspect()
-                                }
-
-                                throw e
-                            }
-                        }
-
-                        try {
-                            Integer retries_count = options.retriesForTestStage ?: -1
-                            run_with_retries(testerLabels, options.TEST_TIMEOUT, retringFunction, true, "Test", newOptions, [], retries_count, osName)
-                        } catch (e) {
-                            println "Exception: ${e.toString()}"
-                            println "Exception message: ${e.getMessage()}"
-                        }
+                    Integer launchingGroupsNumber = 1
+                    Iterator testsIterator = options.testsList.iterator()
+                    if (!options["parallelExecutionType"] || options["parallelExecutionType"] == "TakeOneNodePerGroup") {
+                        launchingGroupsNumber = 1
+                    } else if (options["parallelExecutionType"] == "TakeAllOnlineNodes") {
+                        List possibleNodes = nodesByLabel label: getLabels(osName, asicName, options), offline: false
+                        launchingGroupsNumber = possibleNodes.size()
                     }
+
+                    Map testsExecutors = [:]
+
+                    for (int i = 0; i < launchingGroupsNumber; i++) {
+                        testsExecutors["Test-${asicName}-${osName}-${i}"] = {
+                            String testName = getNextTest(testsIterator)
+                            while (testName != null) {
+                                executeTestsTask(testName, osName, asicName, executeTests, options)
+                                testName = getNextTest(testsIterator)
+                            }
+                        }                        
+                    }
+
+                    parallel testsExecutors
                 }
             }
         }

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -127,6 +127,15 @@ def executeTestsTask(String testName, String osName, String asicName, def execut
     try {
         Integer retries_count = options.retriesForTestStage ?: -1
         run_with_retries(testerLabels, options.TEST_TIMEOUT, retringFunction, true, "Test", newOptions, [], retries_count, osName)
+    } catch(FlowInterruptedException e) {
+        e.getCauses().each() {
+            String causeClassName = it.getClass().toString()
+            if (causeClassName.contains("UserInterruption")) {
+                throw e
+            }
+        }
+        println "Exception: ${e.toString()}"
+        println "Exception message: ${e.getMessage()}"
     } catch (e) {
         println "Exception: ${e.toString()}"
         println "Exception message: ${e.getMessage()}"

--- a/vars/multiplatform_pipeline.groovy
+++ b/vars/multiplatform_pipeline.groovy
@@ -9,7 +9,6 @@ import java.time.format.DateTimeFormatter;
 import jenkins.model.Jenkins;
 import groovy.transform.Synchronized;
 import java.util.Iterator;
-import java.util.concurrent.atomic.AtomicBoolean
 
 
 @NonCPS
@@ -154,14 +153,15 @@ def executeTasksOnAllFreeNodes(String osName, String asicName, def executeTests,
         }
     }
     if (launchingGroupsNumber == 0) {
-        // if all suitable nodes is busy now, create only one thread which will be await idle node (if it doesn't exist)
+        // if all suitable nodes is busy now, create only one thread which will be await idle node (if it doesn't exist in queue)
         def itemsInQueue = jenkins.model.Jenkins.instance.getQueue().getItems()
         for (itemInQueue in itemsInQueue) {
+            // url of task has following format: job/JOB_NAME/BUILD_ID/
             if ("${env.BUILD_URL}".endsWith(itemInQueue.task.getUrl())) {
                 return
             }
         }
-        launchingGroupsNumber == 1
+        launchingGroupsNumber = 1
     }
 
     if (launchingGroupsNumber > 0) {

--- a/vars/rpr_blender28plugin_pipeline.groovy
+++ b/vars/rpr_blender28plugin_pipeline.groovy
@@ -1022,7 +1022,8 @@ def call(String projectRepo = "git@github.com:GPUOpen-LibrariesAndSDKs/RadeonPro
     String customBuildLinkOSX = "",
     String engine = "1.0",
     String tester_tag = "Blender2.8",
-    String toolVersion = "2.83")
+    String toolVersion = "2.83",
+    String parallelExecutionType = "TakeOneNodePerGroup")
 {
     resX = (resX == 'Default') ? '0' : resX
     resY = (resY == 'Default') ? '0' : resY
@@ -1135,7 +1136,8 @@ def call(String projectRepo = "git@github.com:GPUOpen-LibrariesAndSDKs/RadeonPro
                         customBuildLinkOSX: customBuildLinkOSX,
                         engine: engine,
                         nodeRetry: nodeRetry,
-                        problemMessageManager: problemMessageManager
+                        problemMessageManager: problemMessageManager,
+                        parallelExecutionType:parallelExecutionType
                         ]
         }
         catch(e)

--- a/vars/rpr_core_pipeline.groovy
+++ b/vars/rpr_core_pipeline.groovy
@@ -732,7 +732,8 @@ def call(String projectBranch = "",
          String height = "0",
          String iterations = "0",
          Boolean sendToUMS = true,
-         String tester_tag = 'Core') {
+         String tester_tag = 'Core',
+         String parallelExecutionType = "TakeOneNodePerGroup") {
     
     def nodeRetry = []
     Map options = [:]
@@ -790,7 +791,8 @@ def call(String projectBranch = "",
                         universePlatforms: universePlatforms,
                         nodeRetry: nodeRetry,
                         problemMessageManager: problemMessageManager,
-                        platforms:platforms
+                        platforms:platforms,
+                        parallelExecutionType:parallelExecutionType
                         ]
         }
         catch(e)

--- a/vars/rpr_maxplugin_pipeline.groovy
+++ b/vars/rpr_maxplugin_pipeline.groovy
@@ -853,7 +853,8 @@ def call(String projectRepo = "git@github.com:GPUOpen-LibrariesAndSDKs/RadeonPro
         String iter = '50',
         String theshold = '0.05',
         String customBuildLinkWindows = "",
-        String tester_tag = 'Max')
+        String tester_tag = 'Max',
+        String parallelExecutionType = "TakeOneNodePerGroup")
 {
     resX = (resX == 'Default') ? '0' : resX
     resY = (resY == 'Default') ? '0' : resY
@@ -950,7 +951,8 @@ def call(String projectRepo = "git@github.com:GPUOpen-LibrariesAndSDKs/RadeonPro
                         customBuildLinkWindows: customBuildLinkWindows,
                         nodeRetry: nodeRetry,
                         problemMessageManager: problemMessageManager,
-                        platforms:platforms
+                        platforms:platforms,
+                        parallelExecutionType:parallelExecutionType
                         ]
         }
         catch (e)

--- a/vars/rpr_mayaplugin_pipeline.groovy
+++ b/vars/rpr_mayaplugin_pipeline.groovy
@@ -1009,7 +1009,8 @@ def call(String projectRepo = "git@github.com:GPUOpen-LibrariesAndSDKs/RadeonPro
         String customBuildLinkWindows = "",
         String customBuildLinkOSX = "",
         String engine = "1.0",
-        String tester_tag = 'Maya')
+        String tester_tag = 'Maya',
+        String parallelExecutionType = "TakeOneNodePerGroup")
 {
     resX = (resX == 'Default') ? '0' : resX
     resY = (resY == 'Default') ? '0' : resY
@@ -1118,7 +1119,8 @@ def call(String projectRepo = "git@github.com:GPUOpen-LibrariesAndSDKs/RadeonPro
                         engine: engine,
                         nodeRetry: nodeRetry,
                         problemMessageManager: problemMessageManager,
-                        platforms:platforms
+                        platforms:platforms,
+                        parallelExecutionType:parallelExecutionType
                         ]
         } catch (e) {
             problemMessageManager.saveSpecificFailReason("Failed initialization.", "Init")

--- a/vars/rpr_viewer_pipeline.groovy
+++ b/vars/rpr_viewer_pipeline.groovy
@@ -804,7 +804,8 @@ def call(String projectBranch = "",
          String tests = "",
          Boolean splitTestsExecution = true,
          Boolean sendToUMS = true,
-         String tester_tag = 'RprViewer') {
+         String tester_tag = 'RprViewer',
+         String parallelExecutionType = "TakeOneNodePerGroup") {
 
     def nodeRetry = []
     Map options = [:]
@@ -847,7 +848,8 @@ def call(String projectBranch = "",
                         sendToUMS:sendToUMS,
                         universePlatforms: universePlatforms,
                         problemMessageManager: problemMessageManager,
-                        platforms:platforms
+                        platforms:platforms,
+                        parallelExecutionType:parallelExecutionType
                         ]
         } 
         catch(e)


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1436
### Purpose
* Implement option for parallel execute test groups in few modes
### Effect of change
#### Implement few modes for parallel execute test groups:
* TakeOneNodePerGroup - current variant of tests execution (one gpu - one group)
* TakeAllFreeNodes - number of parallel threads is equal to number of free nodes. Each finished thread creates number of new threads which is equal to number of free nodes (if there isn't free nodes - only one thread will be added in queue).
* TakeAllOnlineNodes - number of parallel threads is equal to number of existent online nodes in Jenkins before run tests.
### :warning: Notes for Reviewers
* You can test this changes in this job (run with 'inemankov/parallel_gpus_options' pipelines branch): https://rpr.cis.luxoft.com/job/DevRadeonProRenderBlender2.8PluginManual/
### Jenkins Builds
* TakeOneNodePerGroup, few groups: https://rpr.cis.luxoft.com/job/DevRadeonProRenderBlender2.8PluginManual/417/
* TakeOneNodePerGroup, regression: https://rpr.cis.luxoft.com/job/DevRadeonProRenderBlender2.8PluginManual/419/parameters/
* TakeAllOnlineNodes, few groups: https://rpr.cis.luxoft.com/job/DevRadeonProRenderBlender2.8PluginManual/418/
* TakeAllOnlineNodes, regression: https://rpr.cis.luxoft.com/job/DevRadeonProRenderBlender2.8PluginManual/420/parameters/
* TakeAllFreeNodes, few groups: https://rpr.cis.luxoft.com/job/DevRadeonProRenderBlender2.8PluginManual/426/
* TakeAllFreeNodes, regression: https://rpr.cis.luxoft.com/job/DevRadeonProRenderBlender2.8PluginManual/427/