### PR TITLE
Increase deploy timeouts for Blender & Maya

### DIFF
--- a/vars/rpr_blender28plugin_pipeline.groovy
+++ b/vars/rpr_blender28plugin_pipeline.groovy
@@ -1339,7 +1339,7 @@ def call(String projectRepo = "git@github.com:GPUOpen-LibrariesAndSDKs/RadeonPro
                         TEST_TIMEOUT:180,
                         ADDITIONAL_XML_TIMEOUT:30,
                         REGRESSION_TIMEOUT:120,
-                        DEPLOY_TIMEOUT:150,
+                        DEPLOY_TIMEOUT:300,
                         TESTER_TAG:tester_tag,
                         BUILDER_TAG:"BuildBlender2.8",
                         universePlatforms: universePlatforms,

--- a/vars/rpr_blender28plugin_pipeline.groovy
+++ b/vars/rpr_blender28plugin_pipeline.groovy
@@ -1318,6 +1318,10 @@ def call(String projectRepo = "git@github.com:GPUOpen-LibrariesAndSDKs/RadeonPro
                 prBranchName = prInfo[1]
             }
 
+            // add 75 minutes for each engine
+            Integer deployTimeout = 150 + 90 * (enginesNames.split(',').length - 1)
+            println "Calculated deploy timeout: ${deployTimeout}"
+
             options << [projectRepo:projectRepo,
                         projectBranch:projectBranch,
                         testsBranch:testsBranch,
@@ -1339,7 +1343,7 @@ def call(String projectRepo = "git@github.com:GPUOpen-LibrariesAndSDKs/RadeonPro
                         TEST_TIMEOUT:180,
                         ADDITIONAL_XML_TIMEOUT:30,
                         REGRESSION_TIMEOUT:120,
-                        DEPLOY_TIMEOUT:300,
+                        DEPLOY_TIMEOUT:deployTimeout,
                         TESTER_TAG:tester_tag,
                         BUILDER_TAG:"BuildBlender2.8",
                         universePlatforms: universePlatforms,

--- a/vars/rpr_blender28plugin_pipeline.groovy
+++ b/vars/rpr_blender28plugin_pipeline.groovy
@@ -1318,7 +1318,7 @@ def call(String projectRepo = "git@github.com:GPUOpen-LibrariesAndSDKs/RadeonPro
                 prBranchName = prInfo[1]
             }
 
-            // add 75 minutes for each engine
+            // add 90 minutes for each engine
             Integer deployTimeout = 150 + 90 * (enginesNames.split(',').length - 1)
             println "Calculated deploy timeout: ${deployTimeout}"
 

--- a/vars/rpr_blender28plugin_pipeline.groovy
+++ b/vars/rpr_blender28plugin_pipeline.groovy
@@ -1318,8 +1318,7 @@ def call(String projectRepo = "git@github.com:GPUOpen-LibrariesAndSDKs/RadeonPro
                 prBranchName = prInfo[1]
             }
 
-            // add 90 minutes for each engine
-            Integer deployTimeout = 150 + 90 * (enginesNames.split(',').length - 1)
+            Integer deployTimeout = 150 * enginesNames.split(',').length
             println "Calculated deploy timeout: ${deployTimeout}"
 
             options << [projectRepo:projectRepo,

--- a/vars/rpr_mayaplugin_pipeline.groovy
+++ b/vars/rpr_mayaplugin_pipeline.groovy
@@ -1216,6 +1216,10 @@ def call(String projectRepo = "git@github.com:GPUOpen-LibrariesAndSDKs/RadeonPro
                 prBranchName = prInfo[1]
             }
 
+            // add 75 minutes for each engine
+            Integer deployTimeout = 150 + 90 * (enginesNames.split(',').length - 1)
+            println "Calculated deploy timeout: ${deployTimeout}"
+
             options << [projectRepo:projectRepo,
                         projectBranch:projectBranch,
                         testsBranch:testsBranch,
@@ -1239,7 +1243,7 @@ def call(String projectRepo = "git@github.com:GPUOpen-LibrariesAndSDKs/RadeonPro
                         TEST_TIMEOUT:120,
                         ADDITIONAL_XML_TIMEOUT:30,
                         REGRESSION_TIMEOUT:120,
-                        DEPLOY_TIMEOUT:300,
+                        DEPLOY_TIMEOUT:deployTimeout,
                         TESTER_TAG:tester_tag,
                         universePlatforms: universePlatforms,
                         resX: resX,

--- a/vars/rpr_mayaplugin_pipeline.groovy
+++ b/vars/rpr_mayaplugin_pipeline.groovy
@@ -1216,7 +1216,7 @@ def call(String projectRepo = "git@github.com:GPUOpen-LibrariesAndSDKs/RadeonPro
                 prBranchName = prInfo[1]
             }
 
-            // add 75 minutes for each engine
+            // add 90 minutes for each engine
             Integer deployTimeout = 150 + 90 * (enginesNames.split(',').length - 1)
             println "Calculated deploy timeout: ${deployTimeout}"
 

--- a/vars/rpr_mayaplugin_pipeline.groovy
+++ b/vars/rpr_mayaplugin_pipeline.groovy
@@ -1216,8 +1216,7 @@ def call(String projectRepo = "git@github.com:GPUOpen-LibrariesAndSDKs/RadeonPro
                 prBranchName = prInfo[1]
             }
 
-            // add 90 minutes for each engine
-            Integer deployTimeout = 150 + 90 * (enginesNames.split(',').length - 1)
+            Integer deployTimeout = 150 * enginesNames.split(',').length
             println "Calculated deploy timeout: ${deployTimeout}"
 
             options << [projectRepo:projectRepo,

--- a/vars/rpr_mayaplugin_pipeline.groovy
+++ b/vars/rpr_mayaplugin_pipeline.groovy
@@ -1239,7 +1239,7 @@ def call(String projectRepo = "git@github.com:GPUOpen-LibrariesAndSDKs/RadeonPro
                         TEST_TIMEOUT:120,
                         ADDITIONAL_XML_TIMEOUT:30,
                         REGRESSION_TIMEOUT:120,
-                        DEPLOY_TIMEOUT:120,
+                        DEPLOY_TIMEOUT:300,
                         TESTER_TAG:tester_tag,
                         universePlatforms: universePlatforms,
                         resX: resX,


### PR DESCRIPTION
### Jira Ticket
* None
### Purpose
* Increase deploy timeouts for Blender & Maya
### Effect of change
* Make deploy timeouts of Blender and Maya depended on number of engines (+90 minutes for each engine)
### Jenkins Builds
#### See line which starts with "Calculated deploy timeout:"
* Manual job: https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8PluginManual/2769/console
* Auto job: https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8PluginManual/2770/console