### PR TITLE
Fix detecting of fully skipped groups for Blender and Maya

### DIFF
--- a/vars/rpr_blender28plugin_pipeline.groovy
+++ b/vars/rpr_blender28plugin_pipeline.groovy
@@ -1033,10 +1033,10 @@ def executePreBuild(Map options)
                                         try {
                                             String output = bat(script: "is_group_skipped.bat ${it} ${osName} ${engine} \"..\\jobs\\Tests\\${testName}\\test_cases.json\"", returnStdout: true).trim()
                                             if (output.contains("True")) {
-                                                if (!options.skippedTests.containsKey(test)) {
-                                                    options.skippedTests[test] = []
+                                                if (!options.skippedTests.containsKey(testName)) {
+                                                    options.skippedTests[testName] = []
                                                 }
-                                                options.skippedTests[test].add("${it}-${osName}")
+                                                options.skippedTests[testName].add("${it}-${osName}")
                                             }
                                         }
                                         catch(Exception e) {

--- a/vars/rpr_mayaplugin_pipeline.groovy
+++ b/vars/rpr_mayaplugin_pipeline.groovy
@@ -935,10 +935,10 @@ def executePreBuild(Map options)
                                         dir ("jobs_launcher") {
                                             String output = bat(script: "is_group_skipped.bat ${it} ${osName} ${engine} \"..\\jobs\\Tests\\${testName}\\test_cases.json\"", returnStdout: true).trim()
                                             if (output.contains("True")) {
-                                                if (!options.skippedTests.containsKey(test)) {
-                                                    options.skippedTests[test] = []
+                                                if (!options.skippedTests.containsKey(testName)) {
+                                                    options.skippedTests[testName] = []
                                                 }
-                                                options.skippedTests[test].add("${it}-${osName}")
+                                                options.skippedTests[testName].add("${it}-${osName}")
                                             }
                                         }
                                     }


### PR DESCRIPTION
### Jira Tickets
* https://adc.luxoft.com/jira/browse/STVCIS-1709
### Purpose
* Fix detecting of fully skipped groups for Blender and Maya
### Jenkins Builds
* https://rpr.cis.luxoft.com/job/DevRadeonProRenderBlender2.8PluginManual/453/