### PR TITLE
Migrate github auth scripts from python3.5 to python3.9

### DIFF
--- a/src/GithubApiProvider.groovy
+++ b/src/GithubApiProvider.groovy
@@ -42,9 +42,9 @@ class GithubApiProvider {
     
                 context.withEnv(["GITHUB_APP_KEY=${context.GITHUB_APP_KEY}"]) {
                     if (context.isUnix()) {
-                        installation_token = context.python3("${context.CIS_TOOLS}/auth_github.py --github_app_id ${context.GITHUB_APP_ID} --organization_name ${organization_name} --duration 540", "3.5").split("\n")[-1]
+                        installation_token = context.python3("${context.CIS_TOOLS}/auth_github.py --github_app_id ${context.GITHUB_APP_ID} --organization_name ${organization_name} --duration 540").split("\n")[-1]
                     } else {
-                        installation_token = context.python3("${context.CIS_TOOLS}\\auth_github.py --github_app_id ${context.GITHUB_APP_ID} --organization_name ${organization_name} --duration 540", "35").split("\n")[-1]
+                        installation_token = context.python3("${context.CIS_TOOLS}\\auth_github.py --github_app_id ${context.GITHUB_APP_ID} --organization_name ${organization_name} --duration 540").split("\n")[-1]
                     }
                 }
             }


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-2250
### Purpose
* Migrate github auth scripts from python3.5 to python3.9
### :octocat: Related PR'S
* cis_tools: https://github.com/luxteam/cis_tools/pull/39