### PR TITLE
Make ducktape for Arak and Kerman machines

### DIFF
--- a/vars/rpr_blender28plugin_pipeline.groovy
+++ b/vars/rpr_blender28plugin_pipeline.groovy
@@ -258,6 +258,13 @@ def executeTests(String osName, String asicName, Map options)
     Boolean stashResults = true
 
     try {
+        // FIXME: remove this ducktape when CPUs on that machines will be changes
+        if (env.NODE_NAME == "PC-TESTER-ARAK-WIN10" || env.NODE_NAME == "PC-TESTER-KERMAN-WIN10") {
+            if (options.parsedTests.contains("CPU_Mode") || options.parsedTests.contains("Dual_Mode") || options.parsedTests.contains("regression.0")) {
+                throw new Exception("System doesn't support CPU_Mode and Dual_Mode groups")
+            }
+        }
+
         withNotifications(title: options["stageName"], options: options, logUrl: "${BUILD_URL}", configuration: NotificationConfiguration.DOWNLOAD_TESTS_REPO) {
             timeout(time: "5", unit: "MINUTES") {
                 cleanWS(osName)

--- a/vars/rpr_blender28plugin_pipeline.groovy
+++ b/vars/rpr_blender28plugin_pipeline.groovy
@@ -261,7 +261,10 @@ def executeTests(String osName, String asicName, Map options)
         // FIXME: remove this ducktape when CPUs on that machines will be changes
         if (env.NODE_NAME == "PC-TESTER-ARAK-WIN10" || env.NODE_NAME == "PC-TESTER-KERMAN-WIN10") {
             if (options.parsedTests.contains("CPU_Mode") || options.parsedTests.contains("Dual_Mode") || options.parsedTests.contains("regression.0")) {
-                throw new Exception("System doesn't support CPU_Mode and Dual_Mode groups")
+                throw new ExpectedExceptionWrapper(
+                    "System doesn't support CPU_Mode and Dual_Mode groups", 
+                    new Exception("System doesn't support CPU_Mode and Dual_Mode groups")
+                )
             }
         }
 


### PR DESCRIPTION
### Jira Ticket
* None
### Purpose
* Make ducktape for Arak and Kerman machines (do not run CPU_Mode and Dual_Mode groups of Blender)
### Jenkins Builds
https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8PluginManual/4856/