### PR TITLE
Optimized RPRViewer installations check

### DIFF
--- a/src/NotificationConfiguration.groovy
+++ b/src/NotificationConfiguration.groovy
@@ -292,6 +292,27 @@ public class NotificationConfiguration {
         ]
     ]
 
+    def static INSTALL_PLUGIN_CUSTOM_PATH = [
+        "begin": ["message": "Installing the plugin (custom path install)."],
+
+        "exceptions": [
+            [
+                "class": "TimeoutExceeded", "problemMessage": "Failed to install the plugin due to timeout (custom path install).", 
+                "rethrow": ExceptionThrowType.THROW_IN_WRAPPER,
+                "githubNotification": ["status": "timed_out"]
+            ],
+            [
+                "class": Exception, "problemMessage": "Failed to uninstall old plugin (custom path install).", 
+                "rethrow": ExceptionThrowType.RETHROW, "scope": ProblemMessageManager.SPECIFIC,
+                "getMessage": ["Failed to uninstall old plugin"]
+            ],
+            [
+                "class": Exception, "problemMessage": "Failed to install the plugin (custom path install).", 
+                "rethrow": ExceptionThrowType.THROW_IN_WRAPPER
+            ]
+        ]
+    ]
+
     def static INSTALL_HOUDINI = [
         "begin": ["message": "Installing Houdini."],
 
@@ -393,6 +414,27 @@ public class NotificationConfiguration {
             ],
             [
                 "class": Exception, "problemMessage": "Failed to build cache (clean install).", 
+                "rethrow": ExceptionThrowType.THROW_IN_WRAPPER
+            ]
+        ]
+    ]
+
+    def static BUILD_CACHE_CUSTOM_PATH = [
+        "begin": ["message": "Building cache (clean install)."],
+
+        "exceptions": [
+            [
+                "class": "TimeoutExceeded", "problemMessage": "Failed to build cache due to timeout (custom path install).", 
+                "rethrow": ExceptionThrowType.THROW_IN_WRAPPER,
+                "githubNotification": ["status": "timed_out"]
+            ],
+            [
+                "class": Exception, "problemMessage": "No output image after cache building (custom path install).", 
+                "rethrow": ExceptionThrowType.RETHROW, "scope": ProblemMessageManager.SPECIFIC,
+                "getMessage": [NO_OUTPUT_IMAGE]
+            ],
+            [
+                "class": Exception, "problemMessage": "Failed to build cache (custom path install).", 
                 "rethrow": ExceptionThrowType.THROW_IN_WRAPPER
             ]
         ]

--- a/vars/rpr_usdviewer_pipeline.groovy
+++ b/vars/rpr_usdviewer_pipeline.groovy
@@ -82,7 +82,7 @@ def getUninstallerPath() {
 
     if (fileExists(defaultUninstallerPath)) {
         return defaultUninstallerPath
-    } else if fileExists(customUninstallerPath)) {
+    } else if (fileExists(customUninstallerPath)) {
         return customUninstallerPath
     } else {
         return null

--- a/vars/rpr_usdviewer_pipeline.groovy
+++ b/vars/rpr_usdviewer_pipeline.groovy
@@ -16,7 +16,7 @@ import universe.*
 
 @NonCPS
 def shouldInstallationPerform(String key, String installationType, Integer maxTries) {
-    def installationInfo = installsPerformedMap.get(key)[installationType]
+    def installationInfo = installsPerformedMap.get(key.toString())[installationType]
     return installationInfo['tries'] < maxTries && installationInfo['status'] != 'success'
 }
 

--- a/vars/rpr_usdviewer_pipeline.groovy
+++ b/vars/rpr_usdviewer_pipeline.groovy
@@ -10,6 +10,7 @@ import universe.*
 
 
 @Field final String PRODUCT_NAME = "AMD%20Radeon™%20ProRender%20for%20USDViewer"
+@Field final String CUSTOM_INSTALL_PATH = "C:\\Users\\${env.USERNAME}\\testRPRViewer\\subdir"
 @Field final def installsPerformedMap = new ConcurrentHashMap()
 
 
@@ -22,7 +23,9 @@ def shouldInstallationPerform(String key, String installationType, Integer maxTr
 @NonCPS
 def updateMap(String keyName, String installationType, String status) {
     if (installationType == 'dirt') {
-        installsPerformedMap.computeIfPresent(keyName, (BiFunction){ key, value -> ['dirt': ['tries': value['dirt']['tries'] + 1, 'status': status]] })
+        installsPerformedMap.computeIfPresent(keyName, (BiFunction){ key, value -> ['dirt': ['tries': value['dirt']['tries'] + 1, 'status': status], 'custom_path': value['custom_path']] })
+    } else if (installationType == 'custom_path') {
+        installsPerformedMap.computeIfPresent(keyName, (BiFunction){ key, value -> ['custom_path': ['tries': value['custom_path']['tries'] + 1, 'status': status], 'dirt': value['dirt']] })
     }
 }
 
@@ -67,17 +70,42 @@ def getViewerTool(String osName, Map options) {
 
 
 def checkExistenceOfPlugin(String osName, Map options) {
-    String uninstallerPath = "C:\\Program Files\\RPRViewer\\unins000.exe"
+    String defaultUninstallerPath = "C:\\Program Files\\RPRViewer\\unins000.exe"
+    String customUninstallerPath = "${CUSTOM_INSTALL_PATH}\\unins000.exe"
 
-    return fileExists(uninstallerPath)
+    return fileExists(defaultUninstallerPath) || fileExists(customUninstallerPath)
+}
+
+def getUninstallerPath() {
+    String defaultUninstallerPath = "C:\\Program Files\\RPRViewer\\unins000.exe"
+    String customUninstallerPath = "${CUSTOM_INSTALL_PATH}\\unins000.exe"
+
+    if (fileExists(defaultUninstallerPath)) {
+        return defaultUninstallerPath
+    } else if fileExists(customUninstallerPath)) {
+        return customUninstallerPath
+    } else {
+        return null
+    }
 }
 
 
-def installInventorPlugin(String osName, Map options, Boolean cleanInstall=true, String customPluginName = "") {
-    String uninstallerPath = "C:\\Program Files\\RPRViewer\\unins000.exe"
-
+def installInventorPlugin(String osName, Map options, Boolean cleanInstall=true, Boolean customPathInstall=false, String customPluginName = "") {
     String installerName = ""
-    String logPostfix = cleanInstall ? "clean" : "dirt"
+    String dirOption = ""
+    String logPostfix
+    
+
+    if (cleanInstall) {
+        if (customPathInstall) {
+            logPostfix = "custom_path"
+            dirOption = "/DIR=\"${CUSTOM_INSTALL_PATH}\""
+        } else {
+            logPostfix = "clean"
+        }
+    } else {
+        logPostfix = "dirt"
+    }
 
     if (customPluginName) {
         installerName = customPluginName
@@ -92,7 +120,7 @@ def installInventorPlugin(String osName, Map options, Boolean cleanInstall=true,
         if (cleanInstall && checkExistenceOfPlugin(osName, options)) {
             println "[INFO] Uninstalling Inventor Plugin"
             bat """
-                start "" /wait "${uninstallerPath}" /SILENT /NORESTART /LOG=${options.stageName}_${logPostfix}_${options.currentTry}.uninstall.log
+                start "" /wait "${getUninstallerPath()}" /SILENT /NORESTART /LOG=${options.stageName}_${logPostfix}_${options.currentTry}.uninstall.log
             """
         }
     } catch (e) {
@@ -103,7 +131,7 @@ def installInventorPlugin(String osName, Map options, Boolean cleanInstall=true,
         println "[INFO] Install Inventor Plugin"
 
         bat """
-            start /wait ${CIS_TOOLS}\\..\\PluginsBinaries\\${installerName} /SILENT /NORESTART /LOG=${options.stageName}${logPostfix}_${options.currentTry}.install${logPostfix}.log
+            start /wait ${CIS_TOOLS}\\..\\PluginsBinaries\\${installerName} /SILENT /NORESTART ${dirOption} /LOG=${options.stageName}${logPostfix}_${options.currentTry}.install${logPostfix}.log
         """
     } catch (e) {
         throw new Exception("Failed to install new plugin")
@@ -111,8 +139,9 @@ def installInventorPlugin(String osName, Map options, Boolean cleanInstall=true,
 }
 
 
-def buildRenderCache(String osName, String toolVersion, Map options, Boolean cleanInstall=true) {
+def buildRenderCache(String osName, String toolVersion, Map options, Boolean cleanInstall=true, Boolean customPathInstall=false) {
     String logPostfix = cleanInstall ? "clean" : "dirt"
+    logPostfix = customPathInstall ? "custom_path" : logPostfix
 
     dir("scripts") {
         switch(osName) {
@@ -226,7 +255,7 @@ def executeTests(String osName, String asicName, Map options) {
             downloadFiles("/volume1/Assets/usd_inventor_autotests/", assetsDir)
         }
 
-        installsPerformedMap.putIfAbsent("${asicName}-${osName}", ['dirt': ['tries': 0, 'status': 'active']])
+        installsPerformedMap.putIfAbsent("${asicName}-${osName}", ['dirt': ['tries': 0, 'status': 'active'], 'custom_path': ['tries': 0, 'status': 'active']])
 
         if (shouldInstallationPerform("${asicName}-${osName}", 'dirt', options.nodeReallocateTries)) {
             try {
@@ -243,7 +272,7 @@ def executeTests(String osName, String asicName, Map options) {
                     println "Install \"baseline\" plugin"
 
                     timeout(time: "15", unit: "MINUTES") {
-                        installInventorPlugin(osName, options, false, baselinePluginPath.split("/")[-1])
+                        installInventorPlugin(osName, options, false, false, baselinePluginPath.split("/")[-1])
                     }
 
                     println "Start \"dirt\" installation"
@@ -280,6 +309,42 @@ def executeTests(String osName, String asicName, Map options) {
             }
 
             updateMap("${asicName}-${osName}", 'dirt', 'success')
+        }
+
+        if (shouldInstallationPerform("${asicName}-${osName}", 'custom_path', options.nodeReallocateTries)) {
+            try {
+                withNotifications(title: options["stageName"], options: options, configuration: NotificationConfiguration.INSTALL_PLUGIN_CUSTOM_PATH) {
+                    timeout(time: "15", unit: "MINUTES") {
+                        installInventorPlugin(osName, options, true, true)
+                    }
+                }
+            
+                withNotifications(title: options["stageName"], options: options, configuration: NotificationConfiguration.BUILD_CACHE_CUSTOM_PATH) {                        
+                    timeout(time: "10", unit: "MINUTES") {
+                        try {
+                            buildRenderCache(osName, "2022", options, true, true)
+                        } catch (e) {
+                            throw e
+                        } finally {
+                            dir("scripts") {
+                                utils.renameFile(this, osName, "cache_building_results", "${options.stageName}_custom_path_${options.currentTry}")
+                                archiveArtifacts artifacts: "${options.stageName}_custom_path_${options.currentTry}/*.jpg", allowEmptyArchive: true
+                            }
+                        }
+                        dir("scripts") {
+                            String cacheImgPath = "./${options.stageName}_custom_path_${options.currentTry}/RESULT.jpg"
+                            if(!fileExists(cacheImgPath)){
+                                throw new ExpectedExceptionWrapper(NotificationConfiguration.NO_OUTPUT_IMAGE, new Exception(NotificationConfiguration.NO_OUTPUT_IMAGE))
+                            }
+                        }
+                    }
+                }
+            } catch (e) {
+                updateMap("${asicName}-${osName}", 'custom_path', 'failed')
+                throw e
+            }
+
+            updateMap("${asicName}-${osName}", 'custom_path', 'success')
         }
 
         withNotifications(title: options["stageName"], options: options, configuration: NotificationConfiguration.INSTALL_PLUGIN_CLEAN) {

--- a/vars/rpr_usdviewer_pipeline.groovy
+++ b/vars/rpr_usdviewer_pipeline.groovy
@@ -10,18 +10,17 @@ import universe.*
 
 
 @Field final String PRODUCT_NAME = "AMD%20Radeon™%20ProRender%20for%20USDViewer"
-@Field final String CUSTOM_INSTALL_PATH = "C:\\Users\\${env.USERNAME}\\testRPRViewer\\subdir"
-@Field final def installsPerformedMap = new ConcurrentHashMap()
+@Field final def installsPerformedMap
 
 
 @NonCPS
-def shouldInstallationPerform(String key, String installationType, Integer maxTries) {
-    def installationInfo = installsPerformedMap.get(key.toString())[installationType]
+def shouldInstallationPerform(def key, String installationType, Integer maxTries) {
+    def installationInfo = installsPerformedMap.get(key)[installationType]
     return installationInfo['tries'] < maxTries && installationInfo['status'] != 'success'
 }
 
 @NonCPS
-def updateMap(String keyName, String installationType, String status) {
+def updateMap(def keyName, String installationType, String status) {
     if (installationType == 'dirt') {
         installsPerformedMap.computeIfPresent(keyName, (BiFunction){ key, value -> ['dirt': ['tries': value['dirt']['tries'] + 1, 'status': status], 'custom_path': value['custom_path']] })
     } else if (installationType == 'custom_path') {
@@ -71,14 +70,14 @@ def getViewerTool(String osName, Map options) {
 
 def checkExistenceOfPlugin(String osName, Map options) {
     String defaultUninstallerPath = "C:\\Program Files\\RPRViewer\\unins000.exe"
-    String customUninstallerPath = "${CUSTOM_INSTALL_PATH}\\unins000.exe"
+    String customUninstallerPath = "C:\\Users\\${env.USERNAME}\\testRPRViewer\\subdir\\unins000.exe"
 
     return fileExists(defaultUninstallerPath) || fileExists(customUninstallerPath)
 }
 
 def getUninstallerPath() {
     String defaultUninstallerPath = "C:\\Program Files\\RPRViewer\\unins000.exe"
-    String customUninstallerPath = "${CUSTOM_INSTALL_PATH}\\unins000.exe"
+    String customUninstallerPath = "C:\\Users\\${env.USERNAME}\\testRPRViewer\\subdir\\unins000.exe"
 
     if (fileExists(defaultUninstallerPath)) {
         return defaultUninstallerPath
@@ -99,7 +98,7 @@ def installInventorPlugin(String osName, Map options, Boolean cleanInstall=true,
     if (cleanInstall) {
         if (customPathInstall) {
             logPostfix = "custom_path"
-            dirOption = "/DIR=\"${CUSTOM_INSTALL_PATH}\""
+            dirOption = "/DIR=\"C:\\Users\\${env.USERNAME}\\testRPRViewer\\subdir\""
         } else {
             logPostfix = "clean"
         }
@@ -1079,6 +1078,7 @@ def call(String projectBranch = "",
          Boolean sendToUMS = true,
          String baselinePluginPath = "/volume1/CIS/bin-storage/RPRViewer_Setup.release-99.exe") {
     ProblemMessageManager problemMessageManager = new ProblemMessageManager(this, currentBuild)
+    installsPerformedMap = new ConcurrentHashMap()
     Map options = [stage: "Init", problemMessageManager: problemMessageManager]
     try {
         withNotifications(options: options, configuration: NotificationConfiguration.INITIALIZATION) {

--- a/vars/rpr_usdviewer_pipeline.groovy
+++ b/vars/rpr_usdviewer_pipeline.groovy
@@ -10,6 +10,7 @@ import universe.*
 
 
 @Field final String PRODUCT_NAME = "AMD%20Radeon™%20ProRender%20for%20USDViewer"
+@Field final String CUSTOM_INSTALL_PATH = "C:\\Program Files\\testRPRViewer\\subdir"
 @Field final def installsPerformedMap
 
 
@@ -70,14 +71,14 @@ def getViewerTool(String osName, Map options) {
 
 def checkExistenceOfPlugin(String osName, Map options) {
     String defaultUninstallerPath = "C:\\Program Files\\RPRViewer\\unins000.exe"
-    String customUninstallerPath = "C:\\Users\\${env.USERNAME}\\testRPRViewer\\subdir\\unins000.exe"
+    String customUninstallerPath = "${CUSTOM_INSTALL_PATH}\\unins000.exe"
 
     return fileExists(defaultUninstallerPath) || fileExists(customUninstallerPath)
 }
 
 def getUninstallerPath() {
     String defaultUninstallerPath = "C:\\Program Files\\RPRViewer\\unins000.exe"
-    String customUninstallerPath = "C:\\Users\\${env.USERNAME}\\testRPRViewer\\subdir\\unins000.exe"
+    String customUninstallerPath = "${CUSTOM_INSTALL_PATH}\\unins000.exe"
 
     if (fileExists(defaultUninstallerPath)) {
         return defaultUninstallerPath
@@ -98,7 +99,7 @@ def installInventorPlugin(String osName, Map options, Boolean cleanInstall=true,
     if (cleanInstall) {
         if (customPathInstall) {
             logPostfix = "custom_path"
-            dirOption = "/DIR=\"C:\\Users\\${env.USERNAME}\\testRPRViewer\\subdir\""
+            dirOption = "/DIR=\"${CUSTOM_INSTALL_PATH}\""
         } else {
             logPostfix = "clean"
         }


### PR DESCRIPTION
### Jira Ticket
https://luxproject.luxoft.com/jira/browse/STVCIS-2465

### Purpose
Prevent multiple tool installations and cache building before each group

### Effect of change
Different installations statuses are stored in concurrent map (except clear install, which perform before each group)
New custom path installation

### Jenkins Builds
https://rpr.cis.luxoft.com/job/DevJobs/job/DevRadeonProUSDViewerManual/14/
https://rpr.cis.luxoft.com/job/DevJobs/job/DevRadeonProUSDViewerManual/11/