### PR TITLE
Use large timeout for builds with MatLib (Inventor autotests)

### DIFF
--- a/vars/rpr_usdviewer_pipeline.groovy
+++ b/vars/rpr_usdviewer_pipeline.groovy
@@ -992,11 +992,20 @@ def call(String projectBranch = "",
 
             Boolean isPreBuilt = customBuildLinkWindows
 
+            Integer testStageTimeout
+
+            if (tests.contains("Material_Library") || testsPackage.contains("weekly")) {
+                testStageTimeout = 270
+            } else {
+                testStageTimeout = 195
+            }
+
             println """
                 Platforms: ${platforms}
                 Tests: ${tests}
                 Tests package: ${testsPackage}
                 Tests execution type: ${parallelExecutionTypeString}
+                Test stage timeout: ${testStageTimeout}
             """
             options << [projectBranch: projectBranch,
                         testRepo:"git@github.com:luxteam/jobs_test_inventor.git",
@@ -1016,7 +1025,7 @@ def call(String projectBranch = "",
                         DEPLOY_FOLDER: "USDViewer",
                         testsPackage: testsPackage,
                         BUILD_TIMEOUT: 120,
-                        TEST_TIMEOUT: 195,
+                        TEST_TIMEOUT: testStageTimeout,
                         ADDITIONAL_XML_TIMEOUT: 15,
                         NON_SPLITTED_PACKAGE_TIMEOUT: 180,
                         DEPLOY_TIMEOUT: 45,


### PR DESCRIPTION
### Jira Ticket
* https://luxproject.luxoft.com/jira/browse/STVCIS-2489
### Purpose
* Implement full Material Library group for Inventor
* Implement full Inventor Appearance group for Invenor
### :octocat: Related PR'S
* jobs_test_intentor: https://github.com/luxteam/jobs_test_inventor/pull/75
### Jenkins Builds
* https://rpr.cis.luxoft.com/job/RadeonProUSDViewerManual/639/