### PR TITLE
Change unpacking plugin from 7Zip to bash-tar for avoiding PATH limits

### DIFF
--- a/vars/rpr_usdplugin_pipeline.groovy
+++ b/vars/rpr_usdplugin_pipeline.groovy
@@ -16,8 +16,7 @@ def installHoudiniPlugin(String osName, Map options) {
         case 'Windows':
             makeUnstash(name: "appWindows", unzip: false, storeOnNAS: options.storeOnNAS)
             bat """
-                %CIS_TOOLS%\\7-Zip\\7z.exe -aoa e hdRpr_${osName}.tar.gz
-                %CIS_TOOLS%\\7-Zip\\7z.exe -aoa x tmpPackage.tar 
+                bash.exe -c "tar -xzf hdRpr_${osName}.tar.gz"
                 cd hdRpr*
                 echo y | activateHoudiniPlugin.exe >> \"..\\${options.stageName}_${options.currentTry}.install.log\"  2>&1
             """


### PR DESCRIPTION
### Effect of change

- 7Zip has a path length limitation, which prevents it from fully unpacking files. I changed the logic from 7Zip to normal bash-tar

### Jenkins Builds

- https://rpr.cis.luxoft.com/job/RadeonProRenderUSDHoudiniPluginAuto/job/PR-512/13/ - Missed textures on Windows PCs
- https://rpr.cis.luxoft.com/job/RadeonProRenderUSDPluginManual/785/ - Fixed missed textures