### PR TITLE
Psergeev/driver selection

### DIFF
--- a/vars/amfdev_streaming_sdk.groovy
+++ b/vars/amfdev_streaming_sdk.groovy
@@ -1699,7 +1699,6 @@ def executePreBuild(Map options) {
             options.executeTests = false
         }
 
-        // TODO передавать не захардкоженную ось
         options["driverVersion"] = getProposedDriverVersion(options.driverIdentificator, "Windows", "preBuild").trim()
 
         // make lists of raw profiles and lists of beautified profiles (displaying profiles)

--- a/vars/amfdev_streaming_sdk.groovy
+++ b/vars/amfdev_streaming_sdk.groovy
@@ -538,8 +538,7 @@ def executeTestCommand(String osName, String asicName, Map options, String execu
 def saveResults(String osName, Map options, String executionType, Boolean stashResults, Boolean executeTestsFinished) {
     try {
         dir(options.stageName) {
-            utils.moveFiles(this, osName, "../*.log,", ".")
-            utils.moveFiles(this, osName, "../*.LOG", ".")
+            utils.moveFiles(this, osName, "../*.log", ".")
             utils.moveFiles(this, osName, "../scripts/*.log", ".")
             utils.renameFile(this, osName, "launcher.engine.log", "${options.stageName}_engine_${options.currentTry}_${executionType}.log")
         }

--- a/vars/driversSelection.groovy
+++ b/vars/driversSelection.groovy
@@ -6,7 +6,10 @@ import groovy.transform.Field
 @Field final String REVISION_NUMBER_PATTERN = ~/^\d{2}\.\d{1,2}\.\d$/
 
 
-def updateDriver(driverIdentificator, osName, computer, driverVersion){
+def updateDriver(driverIdentificator, osName, computer, driverVersion, logPath = ""){
+    if (!logPath) {
+        logPath = "${env.WORKSPACE}\\drivers\\amf\\stable\\tools\\tests\\StreamingSDKTests"
+    }
 
     timeout(time: "20", unit: "MINUTES") {
         try {
@@ -14,7 +17,7 @@ def updateDriver(driverIdentificator, osName, computer, driverVersion){
                 case "Windows":
                     if (driverVersion != getCurrentDriverVersion()) {
                         def setupDir = downloadDriverOnWindows(driverIdentificator, computer)
-                        installDriverOnWindows(driverIdentificator, computer, setupDir)
+                        installDriverOnWindows(driverIdentificator, computer, setupDir, logPath)
                     } else {
                         println("Proposed driver is already installed")
                     }
@@ -83,11 +86,11 @@ def downloadDriverOnWindows(String driverIdentificator, computer) {
 }
 
 
-def installDriverOnWindows(String driverIdentificator, computer, setupDir) {
+def installDriverOnWindows(String driverIdentificator, computer, setupDir, logPath) {
     try {
         bat("start cmd.exe /k \"C:\\Python39\\python.exe ${CIS_TOOLS}\\driver_detection\\skip_warning_window.py && exit 0\"")
         println("[INFO] ${driverIdentificator} driver was found. Trying to install on ${computer}...")
-        bat "${setupDir}\\Setup.exe -INSTALL -LOG ${env.WORKSPACE}\\drivers\\amf\\stable\\tools\\tests\\StreamingSDKTests\\installation_result_${computer}.log"
+        bat "${setupDir}\\Setup.exe -INSTALL -LOG ${logPath}\\installation_result_${computer}.log"
     } catch (e) {
         String installationResultLogContent = readFile("installation_result_${computer}.log")
         if (installationResultLogContent.contains("error code 32 remove_all")) {


### PR DESCRIPTION
### Jira Ticket
https://luxproject.luxoft.com/jira/browse/STVCIS-3272

### Purpose


### Effect of change
If the build receives a revision number of an Adrenalin AMD driver, the driver will be downloaded during preBuild stage to get it's version number.
During the Test stage version number of the proposed driver will be compared with one on the machine and new driver will be installed if the version numbers aren't the same.

### Technical steps
- [x] Step 1
- [x] Step 2
- [ ] Step 3

### :warning: Notes for Reviewers


### :octocat: Related PR'S


### Jenkins Builds
Private
https://rpr.cis.luxoft.com/job/DevJobs/job/StreamingSDKDriver/207/
Public
https://rpr.cis.luxoft.com/job/DevJobs/job/StreamingSDKDriver/208/
Public (same as on machine)
https://rpr.cis.luxoft.com/job/DevJobs/job/StreamingSDKDriver/210/
Empty
https://rpr.cis.luxoft.com/job/DevJobs/job/StreamingSDKDriver/209/
Non-valid
https://rpr.cis.luxoft.com/job/DevJobs/job/StreamingSDKDriver/211/